### PR TITLE
CreatedAt columns of entities updated

### DIFF
--- a/core/src/main/java/com/tinqinacademy/hotel/core/services/SystemServiceImpl.java
+++ b/core/src/main/java/com/tinqinacademy/hotel/core/services/SystemServiceImpl.java
@@ -148,13 +148,12 @@ public class SystemServiceImpl implements SystemService {
 
         log.info("Start updateRoom input:{}", input);
 
-        Room currRoom = roomRepository
+        roomRepository
                 .findById(UUID.fromString(input.getRoomId()))
                 .orElseThrow(() -> new NotFoundException("Room with id[" + input.getRoomId() + "] doesn't exist."));
 
         List<Bed> bedList = findBeds(BedSize.getByCode(input.getBedSize().getCode()), input.getBedCount());
         Room room = conversionService.convert(input, Room.RoomBuilder.class)
-                .createdAt(currRoom.getCreatedAt())
                 .beds(bedList)
                 .build();
         Room updatedRoom = roomRepository.save(room);

--- a/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Bed.java
+++ b/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Bed.java
@@ -32,7 +32,7 @@ public class Bed {
     private Integer capacity;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Booking.java
+++ b/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Booking.java
@@ -38,7 +38,7 @@ public class Booking {
     private BigDecimal totalPrice;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Guest.java
+++ b/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Guest.java
@@ -49,7 +49,7 @@ public class Guest {
     private LocalDate idCardValidity;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Room.java
+++ b/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/Room.java
@@ -42,7 +42,7 @@ public class Room {
     private BathroomType bathroomType;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/User.java
+++ b/persistence/src/main/java/com/tinqinacademy/hotel/persistence/model/entity/User.java
@@ -46,7 +46,7 @@ public class User {
     private LocalDate dateOfBirth;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp


### PR DESCRIPTION
I have updated createdAt columns of all entities so they cannot be updated once they are initialized. This was done in order to avoid bugs in future when updatin entities, because otherwise the createdAt will be set to null on put requests.